### PR TITLE
Fix broken URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y ca-certificates wget --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& wget "https://downloads.mysql.com/archives/get/file/mysql-5.0.96-linux-x86_64-glibc23.tar.gz" -O mysql.tar.gz \
-	&& wget "https://downloads.mysql.com/archives/gpg/?file=mysql-5.0.96-linux-x86_64-glibc23.tar.gz" -O mysql.tar.gz.asc \
+	&& wget "https://downloads.mysql.com/archives/get/p/23/file/mysql-5.0.96-linux-x86_64-glibc23.tar.gz" -O mysql.tar.gz \
+	&& wget "https://downloads.mysql.com/archives/gpg/?file=mysql-5.0.96-linux-x86_64-glibc23.tar.gz&p=23" -O mysql.tar.gz.asc \
 	&& apt-get purge -y --auto-remove ca-certificates wget \
 	&& export GNUPGHOME="$(mktemp -d)" \
 # gpg: key 5072E1F5: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported


### PR DESCRIPTION
Hi, thank you for making available your work in dockerizing this MySQL version.

While building the image I got the error:
```bash
Resolving downloads.mysql.com (downloads.mysql.com)... 137.254.60.14
Connecting to downloads.mysql.com (downloads.mysql.com)|137.254.60.14|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2021-03-13 11:34:02 ERROR 404: Not Found.

ERROR: Service 'mysql50' failed to build: The command '/bin/sh -c apt-get update && apt-get install -y ca-certificates wget --no-install-recommends && rm -rf /var/lib/apt/lists/* 	&& wget "https://downloads.mysql.com/archives/get/file/mysql-5.0.96-linux-x86_64-glibc23.tar.gz" -O mysql.tar.gz 	&& wget "https://downloads.mysql.com/archives/gpg/?file=mysql-5.0.96-linux-x86_64-glibc23.tar.gz" -O mysql.tar.gz.asc 	&& apt-get purge -y --auto-remove ca-certificates wget 	&& export GNUPGHOME="$(mktemp -d)" 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5 && gpg --batch --verify mysql.tar.gz.asc mysql.tar.gz 	&& rm -rf "$GNUPGHOME" mysql.tar.gz.asc 	&& mkdir /usr/local/mysql 	&& tar -xzf mysql.tar.gz -C /usr/local/mysql --strip-components=1 	&& rm mysql.tar.gz 	&& rm -rf /usr/local/mysql/mysql-test /usr/local/mysql/sql-bench 	&& rm -rf /usr/local/mysql/bin/*-debug /usr/local/mysql/bin/*_embedded 	&& find /usr/local/mysql -type f -name "*.a" -delete 	&& apt-get update && apt-get install -y binutils && rm -rf /var/lib/apt/lists/* 	&& { find /usr/local/mysql -type f -executable -exec strip --strip-all '{}' + || true; } 	&& apt-get purge -y --auto-remove binutils' returned a non-zero code: 8
```

The build failed due to MySQL download URLs changed.
With this fix the image builds again successfully.


